### PR TITLE
ci: update actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary
update actions/checkout to v4 to use node 20 runtime

v4 release notes: https://github.com/actions/checkout/releases/tag/v4.0.0