### PR TITLE
chore(ci): bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 


### PR DESCRIPTION
## Summary

Bulk SHA-pin update of GitHub Actions to their latest Node-24-compatible release. Pre-emptive migration ahead of GitHub Actions runner Node 20 removal in Fall 2026.

## Actions bumped

- `actions/checkout@v3` -> `df4cb1c0...` (v6.0.3)

## Verification

Every emitted SHA was verified via `gh api /repos/<owner>/<repo>/commits/<sha>` before commit.

## Background

Node 20 is being removed from GitHub Actions runners in Fall 2026 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This PR pre-emptively bumps every pinned third-party action to its first Node-24-compatible release so the workflows keep running on the new runner default.